### PR TITLE
Update fs-extra for Node 6 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "homepage": "https://github.com/Dremora/broccoli-inject-livereload",
   "dependencies": {
     "broccoli-writer": "^0.1.1",
-    "fs-extra": "^0.18.3"
+    "fs-extra": "^0.30.0"
   }
 }


### PR DESCRIPTION
This allows using graceful-fs@4, actual minimum required fs-extra version is 0.21.0, but 0.30.0 should work with the same old node versions.